### PR TITLE
Stop click event from bubbling to Gtk.WindowHandle

### DIFF
--- a/src/hexagon.js
+++ b/src/hexagon.js
@@ -228,6 +228,7 @@ export const Hexagon = GObject.registerClass(
       if (distFromCenter < this.radiusInscribedCircle) {
         this.emit("click", this.label, x, y);
       }
+      gesture.set_state(Gtk.EventSequenceState.CLAIMED);
     };
   },
 );


### PR DESCRIPTION
Fixes #20 